### PR TITLE
added scrollbar to the evalulator window

### DIFF
--- a/AvatarEvaluator.cs
+++ b/AvatarEvaluator.cs
@@ -58,6 +58,7 @@ namespace Thry.AvatarHelpers {
         {
             if (!isGUIInit) InitGUI();
             EditorGUI.BeginChangeCheck();
+            EditorGUILayout.BeginScrollView();
             avatar = (GameObject)EditorGUILayout.ObjectField("Avatar Gameobject", avatar, typeof(GameObject), true);
             if (EditorGUI.EndChangeCheck() && avatar != null)
             {


### PR DESCRIPTION
I found that when evaluating my avatar, the output was very long and there were no obvious way to get more information other than by increasing the window size.
I had a look at the documentation for Unity and found that only one line was needed to add it.
The change works in my editor but please have a look before merging.
BR.